### PR TITLE
fix plugin.spring.xml for pentaho92

### DIFF
--- a/plugin.spring.xml
+++ b/plugin.spring.xml
@@ -16,7 +16,7 @@
     <bean id="tapa.uploader.api" class="com.oncase.biserver.ws.UploaderREST"/>
     <bean id="tapa.render.api" class="com.oncase.tapa.ws.TapaApi">
     <property name="factory">
-      <ref local="tapaTemplateFactory" />
+      <ref bean="tapaTemplateFactory" />
     </property>
     </bean>
 


### PR DESCRIPTION
Hi,

i've tried to use this plugin with my fresh install of pentaho 9.2 and i got this exception:

` ERROR [Logger] misc-class org.pentaho.platform.plugin.services.pluginmgr.PentahoSystemPluginManager: PluginManager.ERROR_0011 - Failed to register plugin tapa
org.springframework.beans.factory.xml.XmlBeanDefinitionStoreException: Line 19 in XML document from file [/appsrv/pentaho/pentaho-server/pentaho-solutions/system/tapa/plugin.spring.xml] is invalid; nested exception is org.xml.sax.SAXParseException; lineNumber: 19; co
lumnNumber: 42; cvc-complex-type.3.2.2: Attribute 'local' is not allowed to appear in element 'ref'.
`

just replacing "local" with "bean" in plugin.spring.xml seems to fix the issue for me even tho some other errors come up which does not seem to block the plugin from working properly for me.